### PR TITLE
Support video shortcut

### DIFF
--- a/video/src/ai/eto/rikai/sql/spark/datasources/VideoDataSourceV2.scala
+++ b/video/src/ai/eto/rikai/sql/spark/datasources/VideoDataSourceV2.scala
@@ -50,6 +50,10 @@ class VideoDataSourceV2 extends FileDataSourceV2 {
     )
   }
 
+  /** By default, DataSourceV2API is used. For the following syntax
+    *     select * from video.`/path/to/video.mp4`
+    * VideoFileFormat is used to load the video data source
+    */
   override def fallbackFileFormat: Class[_ <: FileFormat] =
     classOf[VideoFileFormat]
 }

--- a/video/src/ai/eto/rikai/sql/spark/datasources/VideoDataSourceV2.scala
+++ b/video/src/ai/eto/rikai/sql/spark/datasources/VideoDataSourceV2.scala
@@ -50,5 +50,6 @@ class VideoDataSourceV2 extends FileDataSourceV2 {
     )
   }
 
-  override def fallbackFileFormat: Class[_ <: FileFormat] = ???
+  override def fallbackFileFormat: Class[_ <: FileFormat] =
+    classOf[VideoFileFormat]
 }

--- a/video/src/ai/eto/rikai/sql/spark/datasources/VideoFileFormat.scala
+++ b/video/src/ai/eto/rikai/sql/spark/datasources/VideoFileFormat.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Rikai authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ai.eto.rikai.sql.spark.datasources
 
 import org.apache.hadoop.conf.Configuration

--- a/video/src/ai/eto/rikai/sql/spark/datasources/VideoFileFormat.scala
+++ b/video/src/ai/eto/rikai/sql/spark/datasources/VideoFileFormat.scala
@@ -1,0 +1,60 @@
+package ai.eto.rikai.sql.spark.datasources
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.FileStatus
+import org.apache.hadoop.mapreduce.Job
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.execution.datasources.{
+  FileFormat,
+  OutputWriterFactory,
+  PartitionedFile
+}
+import org.apache.spark.sql.sources.{DataSourceRegister, Filter}
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.util.SerializableConfiguration
+
+class VideoFileFormat extends FileFormat with DataSourceRegister {
+  override def shortName(): String = "video"
+
+  override def inferSchema(
+      sparkSession: SparkSession,
+      options: Map[String, String],
+      files: Seq[FileStatus]
+  ): Option[StructType] = {
+    Some(VideoSchema.columnSchema)
+  }
+
+  override def prepareWrite(
+      sparkSession: SparkSession,
+      job: Job,
+      options: Map[String, String],
+      dataSchema: StructType
+  ): OutputWriterFactory = {
+    ???
+  }
+
+  override def buildReader(
+      sparkSession: SparkSession,
+      dataSchema: StructType,
+      partitionSchema: StructType,
+      requiredSchema: StructType,
+      filters: Seq[Filter],
+      options: Map[String, String],
+      hadoopConf: Configuration
+  ): PartitionedFile => Iterator[InternalRow] = {
+    val broadcastedConf = sparkSession.sparkContext.broadcast(
+      new SerializableConfiguration(hadoopConf)
+    )
+    val factory = VideoPartitionReaderFactory(
+      sparkSession.sessionState.conf,
+      broadcastedConf,
+      dataSchema,
+      requiredSchema,
+      partitionSchema,
+      new VideoOptions(options),
+      filters
+    )
+    file => factory.buildIterator(file)
+  }
+}

--- a/video/src/ai/eto/rikai/sql/spark/datasources/VideoPartitionReaderFactory.scala
+++ b/video/src/ai/eto/rikai/sql/spark/datasources/VideoPartitionReaderFactory.scala
@@ -18,11 +18,11 @@ package ai.eto.rikai.sql.spark.datasources
 
 import java.net.URI
 import javax.imageio.ImageIO
+
 import org.apache.commons.codec.digest.DigestUtils
 import org.apache.commons.io.FilenameUtils
 import org.apache.commons.io.output.ByteArrayOutputStream
 import org.apache.spark.broadcast.Broadcast
-import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
 import org.apache.spark.sql.connector.read.PartitionReader

--- a/video/src/ai/eto/rikai/sql/spark/datasources/VideoTable.scala
+++ b/video/src/ai/eto/rikai/sql/spark/datasources/VideoTable.scala
@@ -17,6 +17,7 @@
 package ai.eto.rikai.sql.spark.datasources
 
 import java.util
+
 import org.apache.hadoop.fs.FileStatus
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.connector.catalog.TableCapability
@@ -51,5 +52,6 @@ case class VideoTable(
 
   override def formatName: String = "Video"
 
-  override def fallbackFileFormat: Class[_ <: FileFormat] = ???
+  override def fallbackFileFormat: Class[_ <: FileFormat] =
+    classOf[VideoFileFormat]
 }

--- a/video/test/src/ai/eto/rikai/sql/spark/datasources/VideoDataSourceTest.scala
+++ b/video/test/src/ai/eto/rikai/sql/spark/datasources/VideoDataSourceTest.scala
@@ -27,6 +27,14 @@ class VideoDataSourceTest extends SparkSessionSuite {
     )
   }
 
+  test("select * from video.`path-to-video`") {
+    val df = spark.sql(s"""
+         |select * from video.`${localVideo}`
+         |""".stripMargin)
+    df.show(3)
+    assert(df.count() === 10)
+  }
+
   test("option: fps") {
     val df = rabbitFrames.where("date_format(ts, 'mm:ss') = '00:01'")
     assert(df.count() === 1)


### PR DESCRIPTION
``` sql
select * from video.`path-to-video.mp4`
```

FallbackFileFormat is not part of DataSourceAPIv2. Currently, it is used only for the above syntax.

It will be deprecated for future Spark release.