### PR TITLE
Fix filename from MD5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
 out/
+.DS_Store

--- a/video/src/ai/eto/rikai/sql/spark/datasources/VideoPartitionReaderFactory.scala
+++ b/video/src/ai/eto/rikai/sql/spark/datasources/VideoPartitionReaderFactory.scala
@@ -58,9 +58,7 @@ case class VideoPartitionReaderFactory(
     uri.getScheme match {
       case "s3" =>
         val region = SQLConf.get.getConfString("spark.hadoop.aws.region")
-        val tmpFileName = String.valueOf(
-          DigestUtils.getMd5Digest.digest(file.toString().getBytes())
-        )
+        val tmpFileName = DigestUtils.md5Hex(file.toString())
         val s3Utils = new S3Utils(region)
         val fullName = s"/tmp/${tmpFileName}.${extension}"
         s3Utils.getObject(uri, fullName)


### PR DESCRIPTION
A fix for the md5 digest.

``` scala
scala> String.valueOf(org.apache.commons.codec.digest.DigestUtils.getMd5Digest.digest("xxx".getBytes))
res5: String = [B@75d1409b

scala> org.apache.commons.codec.digest.DigestUtils.md5Hex("yyyy")
res10: String = 71ca9079d08bfa85e1e803427d25205a
```