### PR TITLE
Rename ml_image to thumbnail

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ sudo wget -O /databricks/jars/spark-video-assembly-0.0.3.jar https://github.com/
 ### Cheatsheet
 ```
 bin/mill 'video[2.12].test'
+bin/mill 'video[2.12].test.testOnly' '**.MLImageTest.scala'
 bin/mill 'video[2.12].publishLocal'
 bin/mill 'video[2.12].assembly'
 

--- a/video/src/ai/eto/rikai/sql/spark/SparkVideoExtensions.scala
+++ b/video/src/ai/eto/rikai/sql/spark/SparkVideoExtensions.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.rikai.expressions.ToMLImage
 class SparkVideoExtensions extends (SparkSessionExtensions => Unit) {
   override def apply(extensions: SparkSessionExtensions): Unit = {
     extensions.injectFunction(
-      new FunctionIdentifier("ml_image"),
+      new FunctionIdentifier("thumbnail"),
       new ExpressionInfo("ai.eto.rikai.sql.spark.expressions", "ToMLImage"),
       (exprs: Seq[Expression]) => ToMLImage(exprs.head)
     )

--- a/video/src/org/apache/spark/sql/rikai/expressions/MLImage.scala
+++ b/video/src/org/apache/spark/sql/rikai/expressions/MLImage.scala
@@ -51,7 +51,7 @@ case class ToMLImage(child: Expression)
 
   override def dataType: DataType = ImageSchema.columnSchema
 
-  override def prettyName: String = "ml_image"
+  override def prettyName: String = "thumbnail"
 
   /** no explicit override here to keep it working for Apache Spark < 3.2.0
     */

--- a/video/test/src/ai/eto/rikai/sql/spark/datasources/VideoDataSourceTest.scala
+++ b/video/test/src/ai/eto/rikai/sql/spark/datasources/VideoDataSourceTest.scala
@@ -82,7 +82,7 @@ class VideoDataSourceTest extends SparkSessionSuite {
   test("option: imageWidth, imageHeight") {
     def firstRow(df: DataFrame): Row = {
       import spark.implicits._
-      df.selectExpr("ml_image(image_data) as image")
+      df.selectExpr("thumbnail(image_data) as image")
         .withColumn("width", $"image.width")
         .withColumn("height", $"image.height")
         .head()

--- a/video/test/src/org/apache/spark/sql/rikai/expressions/MLImageTest.scala
+++ b/video/test/src/org/apache/spark/sql/rikai/expressions/MLImageTest.scala
@@ -20,7 +20,7 @@ import ai.eto.rikai.sql.spark.datasources.SparkSessionSuite
 import org.apache.spark.ml.image.ImageSchema
 
 class MLImageTest extends SparkSessionSuite {
-  test("udf: ml_image") {
+  test("udf: thumbnail") {
     val df = spark.read
       .format("video")
       .option("fps", 5)
@@ -28,7 +28,7 @@ class MLImageTest extends SparkSessionSuite {
     df.createOrReplaceTempView("frames")
     assert(df.count() === 50)
     val showImage =
-      spark.sql("select ml_image(image_data) as image from frames limit 3")
+      spark.sql("select thumbnail(image_data) as image from frames limit 3")
     assert(showImage.schema("image").dataType === ImageSchema.columnSchema)
     showImage
       .selectExpr("image.origin", "image.height", "image.width")


### PR DESCRIPTION
`ml_image` would confuse Rikai users who are using `to_image`.

The images showed in Databricks notebook tabular are actual thumbnail images.